### PR TITLE
Automatic ActiveType resolution. Improve Model derive macro errors

### DIFF
--- a/core/tests/common.rs
+++ b/core/tests/common.rs
@@ -13,9 +13,7 @@ use ankurah_proto as proto;
 
 #[derive(Debug, Clone, Model)]
 pub struct Pet {
-    #[active_value(YrsString)]
     pub name: String,
-    #[active_value(YrsString)]
     pub age: String,
 }
 


### PR DESCRIPTION
ActiveType annotations now optional:

<img width="397" alt="image" src="https://github.com/user-attachments/assets/db079c6c-f2c5-4539-8fb5-f2e60508200a" />

Improved error messaging when something is funky with your struct:
<img width="942" alt="image" src="https://github.com/user-attachments/assets/67c52976-f187-4988-9291-829482f5eb51" />
